### PR TITLE
Add package manifest

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,3 +7,14 @@ This repository contains small utilities for roguelike development. The current 
 - **Party Module** – `Party.js` renders a small party UI where characters are displayed in individual slots. It is automatically populated with a sample player when the page loads.
 
 Additional documentation for each tool can be found in the `Docs` directory.
+
+## Development
+
+Install the dev dependencies and start a local server with:
+
+```bash
+npm install
+npm start
+```
+
+This uses [`http-server`](https://www.npmjs.com/package/http-server) to serve `index.html` so the ES modules load correctly.

--- a/package.json
+++ b/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "roguelike-toolbox",
+  "version": "1.0.0",
+  "description": "Utilities for roguelike development",
+  "type": "module",
+  "main": "main.js",
+  "scripts": {
+    "start": "http-server -c-1",
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "devDependencies": {
+    "http-server": "^14.1.1"
+  }
+}


### PR DESCRIPTION
## Summary
- declare `http-server` as a dev dependency
- document how to run the project locally

## Testing
- `npm install --package-lock-only` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6855747524708329a2ef8ec302d6bd8f