### PR TITLE
Enable draggable sorting of modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ This repository contains small utilities for roguelike development. The current 
 - **Dice Roller** – a simple web-based roller. Serve `index.html` using a local web server (for example `python -m http.server`) and open it in a browser to roll dice by entering expressions like `1d20+5+1d6` or by using the provided buttons. Logic for rolling dice now lives in `DiceRoller.js` and is loaded as an ES module.
 - **Stats Module** – `Stats.js` provides a basic set of statistics that can represent the player, allies or enemies in a game.
 - **Party Module** – `Party.js` renders a small party UI where characters are displayed in individual slots. It is automatically populated with a sample player when the page loads.
+- **Drag and Drop Layout** – modules in the grid can be reordered by dragging the module sections.
 
 Additional documentation for each tool can be found in the `Docs` directory.
 

--- a/index.html
+++ b/index.html
@@ -30,6 +30,12 @@
             padding: 20px;
             border-radius: 8px;
             box-shadow: 0 4px 8px rgba(0, 0, 0, 0.3);
+            cursor: grab;
+        }
+
+        .tool.dragging {
+            opacity: 0.6;
+            cursor: grabbing;
         }
 
         h1 {
@@ -153,7 +159,7 @@
 </head>
 <body>
 <div class="container">
-    <section class="tool" id="dice-tool">
+    <section class="tool" id="dice-tool" draggable="true">
         <h1>Dice Roller</h1>
         <div id="controls">
             <input type="text" id="expression" placeholder="e.g. 1d20+5+1d6" />
@@ -175,7 +181,7 @@
         </div>
     </section>
 
-    <section class="tool" id="party-tool">
+    <section class="tool" id="party-tool" draggable="true">
         <div id="party-section"></div>
     </section>
 </div>

--- a/main.js
+++ b/main.js
@@ -14,4 +14,48 @@ document.addEventListener('DOMContentLoaded', () => {
     party.addMember(
         new Stats({ name: 'Player', maxHp: 20, attack: 5, defense: 2 })
     );
+
+    enableModuleDragging();
 });
+
+function enableModuleDragging() {
+    const container = document.querySelector('.container');
+    if (!container) return;
+
+    container.querySelectorAll('.tool').forEach(mod => {
+        mod.addEventListener('dragstart', () => {
+            mod.classList.add('dragging');
+        });
+        mod.addEventListener('dragend', () => {
+            mod.classList.remove('dragging');
+        });
+    });
+
+    container.addEventListener('dragover', e => {
+        e.preventDefault();
+        const dragging = container.querySelector('.dragging');
+        if (!dragging) return;
+        const afterEl = getDragAfterElement(container, e.clientY);
+        if (afterEl == null) {
+            container.appendChild(dragging);
+        } else {
+            container.insertBefore(dragging, afterEl);
+        }
+    });
+}
+
+function getDragAfterElement(container, y) {
+    const draggableElements = [...container.querySelectorAll('.tool:not(.dragging)')];
+    return draggableElements.reduce(
+        (closest, child) => {
+            const box = child.getBoundingClientRect();
+            const offset = y - box.top - box.height / 2;
+            if (offset < 0 && offset > closest.offset) {
+                return { offset, element: child };
+            } else {
+                return closest;
+            }
+        },
+        { offset: Number.NEGATIVE_INFINITY }
+    ).element;
+}


### PR DESCRIPTION
## Summary
- make module sections draggable
- add drag-and-drop handling logic
- highlight modules while dragging
- document new drag-and-drop feature

## Testing
- `npm test` *(fails: Error: no test specified)*