### PR TITLE
Fix module drag initialization

### DIFF
--- a/main.js
+++ b/main.js
@@ -5,7 +5,7 @@ import { setupDiceUI } from './DiceRoller.js';
 // Wait for the DOM to load before initializing any UI modules. Some browsers
 // execute module scripts before the page is fully parsed which can lead to
 // missing elements like the party section.
-document.addEventListener('DOMContentLoaded', () => {
+function init() {
     setupDiceUI();
 
     const partyContainer = document.getElementById('party-section');
@@ -16,20 +16,32 @@ document.addEventListener('DOMContentLoaded', () => {
     );
 
     enableModuleDragging();
-});
+}
+
+if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', init);
+} else {
+    init();
+}
 
 function enableModuleDragging() {
     const container = document.querySelector('.container');
     if (!container) return;
 
     container.querySelectorAll('.tool').forEach(mod => {
-        mod.addEventListener('dragstart', () => {
+        mod.addEventListener('dragstart', e => {
+            // Firefox requires dataTransfer data to initiate a drag
+            e.dataTransfer.setData('text/plain', '');
+            e.dataTransfer.effectAllowed = 'move';
             mod.classList.add('dragging');
         });
         mod.addEventListener('dragend', () => {
             mod.classList.remove('dragging');
         });
     });
+
+    // Prevent default handling so drop events work consistently
+    container.addEventListener('drop', e => e.preventDefault());
 
     container.addEventListener('dragover', e => {
         e.preventDefault();


### PR DESCRIPTION
## Summary
- allow dragstart in Firefox by setting dataTransfer data
- prevent default drop handling so modules reorder reliably

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_685577a8fd588329bc89df158fbbdd4f