### PR TITLE
Improve module dragging responsiveness

### DIFF
--- a/index.html
+++ b/index.html
@@ -33,6 +33,7 @@
             cursor: grab;
             will-change: transform;
             transition: transform 0.2s ease;
+            user-select: none;
         }
 
         .tool.dragging {
@@ -161,7 +162,7 @@
 </head>
 <body>
 <div class="container">
-    <section class="tool" id="dice-tool" draggable="true">
+    <section class="tool" id="dice-tool">
         <h1>Dice Roller</h1>
         <div id="controls">
             <input type="text" id="expression" placeholder="e.g. 1d20+5+1d6" />
@@ -183,7 +184,7 @@
         </div>
     </section>
 
-    <section class="tool" id="party-tool" draggable="true">
+    <section class="tool" id="party-tool">
         <div id="party-section"></div>
     </section>
 </div>

--- a/main.js
+++ b/main.js
@@ -29,31 +29,52 @@ function enableModuleDragging() {
     if (!container) return;
 
     let startRects = new Map();
+    let dragging = null;
+    let dragStartX = 0;
+    let dragStartY = 0;
+    let dragRect = null;
 
     container.querySelectorAll('.tool').forEach(mod => {
-        mod.addEventListener('dragstart', () => {
+        mod.style.touchAction = 'none';
+
+        mod.addEventListener('pointerdown', e => {
+            e.preventDefault();
+            dragging = mod;
+            dragRect = mod.getBoundingClientRect();
+            dragStartX = e.clientX;
+            dragStartY = e.clientY;
             mod.classList.add('dragging');
             startRects.clear();
             container.querySelectorAll('.tool').forEach(el => {
                 startRects.set(el, el.getBoundingClientRect());
             });
+            mod.setPointerCapture(e.pointerId);
         });
-        mod.addEventListener('dragend', () => {
+
+        mod.addEventListener('pointermove', e => {
+            if (dragging !== mod) return;
+            e.preventDefault();
+            const dx = e.clientX - dragStartX;
+            const dy = e.clientY - dragStartY;
+            mod.style.transform = `translate(${dx}px, ${dy}px)`;
+        });
+
+        mod.addEventListener('pointerup', e => {
+            if (dragging !== mod) return;
+            dragging = null;
             mod.classList.remove('dragging');
+            mod.style.transform = '';
+            mod.releasePointerCapture(e.pointerId);
+
+            const afterEl = getDragAfterElement(container, e.clientY);
+            if (afterEl == null) {
+                container.appendChild(mod);
+            } else {
+                container.insertBefore(mod, afterEl);
+            }
+
             animateReorder(startRects, container);
         });
-    });
-
-    container.addEventListener('dragover', e => {
-        e.preventDefault();
-        const dragging = container.querySelector('.dragging');
-        if (!dragging) return;
-        const afterEl = getDragAfterElement(container, e.clientY);
-        if (afterEl == null) {
-            container.appendChild(dragging);
-        } else {
-            container.insertBefore(dragging, afterEl);
-        }
     });
 }
 


### PR DESCRIPTION
## Summary
- implement pointer event based dragging instead of HTML drag APIs
- remove `draggable` attributes from module sections
- prevent text highlighting and animate modules following the pointer

## Testing
- `npm test` *(fails: Error: no test specified)*