### PR TITLE
Fix drag capturing on module buttons

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -40,6 +40,14 @@ function enableModuleDragging() {
         mod.style.touchAction = 'none';
 
         mod.addEventListener('pointerdown', e => {
+            if (
+                e.target.closest(
+                    'button, input, textarea, select, option, label, a'
+                )
+            ) {
+                return; // allow normal interaction with form controls
+            }
+
             e.preventDefault();
             dragging = mod;
             dragRect = mod.getBoundingClientRect();


### PR DESCRIPTION
## Summary
- ignore pointer drag handlers for interactive controls

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6855abe7e25c8329b714ccb828c3f2e8