### PR TITLE
Enhance bug reporting with auto GitHub issue creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,9 @@ This uses [`http-server`](https://www.npmjs.com/package/http-server) to serve `i
 ## Bug Reporting
 Use the floating **Report a Bug** button in the bottom-right corner of the page
 to open a dialog box. Select the affected module from the drop-down list,
-describe the problem, and click **Submit** to create a GitHub issue pre-populated
-with your report and tags.
-If your browser does not support the `<dialog>` element, clicking the button will
-fall back to a simple set of prompts before opening the issue on GitHub.
+describe the problem, and click **Submit**. If a `BUG_REPORT_TOKEN` variable is
+defined on the page, the tool will automatically create an issue via the
+GitHub API including your browser information. Without a token, or if the
+request fails, it falls back to opening the GitHub issue form with the details
+pre‑filled. Browsers that do not support the `<dialog>` element will still
+prompt for text before opening the GitHub form.

--- a/index.html
+++ b/index.html
@@ -264,6 +264,11 @@
     </div>
 </dialog>
 
+<!-- Set BUG_REPORT_TOKEN to a GitHub access token if you want the page
+     to automatically create issues rather than open the GitHub form. -->
+<script>
+    window.BUG_REPORT_TOKEN = '';
+</script>
 <script type="module" src="./src/main.js"></script>
 </body>
 </html>

--- a/src/BugReporter.js
+++ b/src/BugReporter.js
@@ -8,14 +8,44 @@ export function setupBugReportUI() {
 
     if (!openButton || !dialog || !submit || !cancel || !desc || !moduleSelect) return;
 
-    const sendReport = (text, module) => {
+    const sendReport = async (text, module) => {
         const mod = module || 'site';
         const labelSlug = mod.replace(/\s+/g, '').toLowerCase();
-        const labels = encodeURIComponent(`bug,${labelSlug}`);
-        const body = encodeURIComponent(`Module: ${mod}\n\n${text.trim()}`);
-        const title = encodeURIComponent('Bug Report');
+        const labels = ['bug', labelSlug];
+        const body = `Module: ${mod}\nBrowser: ${navigator.userAgent}\n\n${text.trim()}`;
+        const title = 'Bug Report';
+        const token = window.BUG_REPORT_TOKEN;
+
+        if (token) {
+            try {
+                const res = await fetch(
+                    'https://api.github.com/repos/elixexorcist/roguelike-toolbox/issues',
+                    {
+                        method: 'POST',
+                        headers: {
+                            'Content-Type': 'application/json',
+                            Authorization: `token ${token}`
+                        },
+                        body: JSON.stringify({ title, body, labels })
+                    }
+                );
+
+                if (res.ok) {
+                    alert('Thank you! Your bug report has been submitted.');
+                    return;
+                } else {
+                    console.error('GitHub API error', await res.text());
+                }
+            } catch (err) {
+                console.error('Failed to create issue via API', err);
+            }
+        }
+
+        const encodedLabels = encodeURIComponent(labels.join(','));
+        const encodedBody = encodeURIComponent(body);
+        const encodedTitle = encodeURIComponent(title);
         const url =
-            `https://github.com/elixexorcist/roguelike-toolbox/issues/new?title=${title}&body=${body}&labels=${labels}`;
+            `https://github.com/elixexorcist/roguelike-toolbox/issues/new?title=${encodedTitle}&body=${encodedBody}&labels=${encodedLabels}`;
         window.open(url, '_blank');
     };
 


### PR DESCRIPTION
## Summary
- extend BugReporter to create issues via GitHub API when a token is provided
- capture the user's browser info in bug reports
- allow configuring a `BUG_REPORT_TOKEN` in `index.html`
- document the new behaviour in README